### PR TITLE
Fix missing link_simulator imports

### DIFF
--- a/Starter_Code_New/dashboard.py
+++ b/Starter_Code_New/dashboard.py
@@ -2,7 +2,12 @@ from flask import Flask, jsonify
 from threading import Thread
 from peer_manager import peer_status, rtt_tracker
 from transaction import get_recent_transactions
-from link_simulator import rate_limiter
+# In the original starter code the rate limiter lived in `link_simulator.py`.
+# The module was later removed and its functionality merged into
+# `outbox.py`, but the import here was never updated.  Importing from
+# the non‑existing `link_simulator` causes a runtime error.  Update the
+# import to reference `outbox` where `rate_limiter` is defined.
+from outbox import rate_limiter
 from message_handler import get_redundancy_stats
 from peer_discovery import known_peers
 import json

--- a/Starter_Code_New/node.py
+++ b/Starter_Code_New/node.py
@@ -12,7 +12,13 @@ from socket_server import start_socket_server
 from dashboard import start_dashboard
 from peer_manager import start_peer_monitor, start_ping_loop
 from outbox import send_from_queue
-from link_simulator import start_dynamic_capacity_adjustment
+# `start_dynamic_capacity_adjustment` was originally located in
+# `link_simulator.py` in the early starter code, but the helper
+# functions were later moved into `outbox.py`. The import was not
+# updated accordingly which results in a `ModuleNotFoundError` at
+# runtime because `link_simulator` no longer exists.  Import the
+# function from `outbox` instead.
+from outbox import start_dynamic_capacity_adjustment
 from inv_message import broadcast_inventory
 from transaction import transaction_generation
 


### PR DESCRIPTION
## Summary
- fix imports in `node.py` and `dashboard.py` to point at `outbox`

## Testing
- `python3 -m py_compile Starter_Code_New/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683f9a846e8083318b94787cb1bb03fb