### PR TITLE
Fix references and start cleanup thread

### DIFF
--- a/Starter_Code_New/message_handler.py
+++ b/Starter_Code_New/message_handler.py
@@ -23,6 +23,16 @@ message_redundancy = 0
 peer_inbound_timestamps = defaultdict(list)
 
 
+def cleanup_seen_messages():
+    """Periodically remove expired message ids from seen_message_ids."""
+    while True:
+        cutoff = time.time() - SEEN_EXPIRY_SECONDS
+        expired = [mid for mid, ts in list(seen_message_ids.items()) if ts < cutoff]
+        for mid in expired:
+            del seen_message_ids[mid]
+        time.sleep(60)
+
+
 # === Inbound Rate Limiting ===
 INBOUND_RATE_LIMIT = 10
 INBOUND_TIME_WINDOW = 10  # seconds

--- a/Starter_Code_New/node.py
+++ b/Starter_Code_New/node.py
@@ -66,6 +66,9 @@ def main():
     print(f"[{self_id}] Starting peer monitor", flush=True)
     start_peer_monitor()
 
+    print(f"[{self_id}] Starting seen message cleanup", flush=True)
+    threading.Thread(target=cleanup_seen_messages, daemon=True).start()
+
     # Block and Transaction Generation and Verification
     print(f"[{self_id}] Starting block sync thread", flush=True)
     threading.Thread(target=request_block_sync, args=(self_id,), daemon=True).start()

--- a/Starter_Code_New/outbox.py
+++ b/Starter_Code_New/outbox.py
@@ -173,7 +173,6 @@ def send_message(ip, port, message):
     except Exception:
         return False
 
-send_message = apply_network_conditions(send_message)
 
 def apply_network_conditions(send_func):
     def wrapper(ip, port, message):
@@ -186,7 +185,11 @@ def apply_network_conditions(send_func):
             return False
         time.sleep(random.randint(*LATENCY_MS)/1000)
         return send_func(ip, port, message)
+
     return wrapper
+
+
+send_message = apply_network_conditions(send_message)
 
 def start_dynamic_capacity_adjustment():
     def adjust_loop():
@@ -200,7 +203,7 @@ def start_dynamic_capacity_adjustment():
 
 def gossip_message(self_id, message, fanout=3):
 
-    from peer_discovery import known_peers, peer_config
+    from peer_discovery import known_peers, peer_config, peer_flags
 
     fanout = peer_config.get(self_id, {}).get("fanout", fanout)
     peers = list(known_peers.keys())


### PR DESCRIPTION
## Summary
- implement `cleanup_seen_messages` to expire old ids
- start the cleanup routine in the node process
- apply network conditions wrapper only once and import `peer_flags`
- add missing newline to `node.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker-compose up --build -d` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_6842519e6b208331adb3449062e12cbf