### PR TITLE
Fix demo script transaction endpoint and wait time

### DIFF
--- a/Starter_Code_New/demo.bat
+++ b/Starter_Code_New/demo.bat
@@ -9,7 +9,7 @@ set "HOST=localhost"
 set "REST_OFFSET=3000"
 set "DASH_OFFSET=3000"
 set "PEERS=5000 5001 5002 5003 5004 5005 5006 5007 5008 5009 5010"
-set "BLOCK_SLEEP=8"
+set "BLOCK_SLEEP=20"
 
 REM -------- 工具检测 --------
 where curl.exe >nul 2>&1 || (
@@ -53,7 +53,7 @@ powershell -NoProfile -Command ^
 echo.
 echo [TX Pool (top 10)]
 powershell -NoProfile -Command ^
-  "Invoke-RestMethod http://%HOST%:%REST%/mempool |" ^
+  "Invoke-RestMethod http://%HOST%:%REST%/transactions |" ^
   "Select-Object -First 10 id,from,to,amount |" ^
   "Format-Table -AutoSize"
 
@@ -62,7 +62,7 @@ echo.
 echo [Latest Block (header only)]
 powershell -NoProfile -Command ^
   "Invoke-RestMethod http://%HOST%:%REST%/blocks |" ^
-  "Select-Object -First 1 block_id,peer,timestamp,@{n='txs';e={$_.transactions.Count}} |" ^
+  "Select-Object -Last 1 block_id,peer,timestamp,@{n='txs';e={$_.transactions.Count}} |" ^
   "Format-Table -AutoSize"
 echo.
 


### PR DESCRIPTION
## Summary
- point demo script TX pool query to `/transactions`
- wait 20s for blocks to be generated
- show the latest block correctly

## Testing
- `python -m py_compile Starter_Code_New/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68427dbc69808331a84601ae55c45e29